### PR TITLE
Add run_with_arms

### DIFF
--- a/mooclet_engine/engine/models.py
+++ b/mooclet_engine/engine/models.py
@@ -205,24 +205,29 @@ class Policy(models.Model):
         variables = self.get_variables()
         #variables = []
         version = policy_function(variables,context)
-        if type(version) is dict:
-            version_id = version["id"]
-        else:
-            version_id = version.id
         
-        # print(f"version_id: {version_id}")
+        forbid_policy_names = [
+            "choose_mooclet_group",
+            "choose_policy_group"
+        ]
         
-        if 'allowed_versions' in context:
+        if self.name not in forbid_policy_names and 'allowed_versions' in context:
+            if type(version) is dict:
+                version_id = version["id"]
+            else:
+                version_id = version.id
+            
             allowed_versions = context['allowed_versions']
             max_time = context.get("maximum_allowed", 20)
             
-            # print(f"allowed_versions: {allowed_versions}")
-            # print(f"max_time: {max_time}")
+            print(f"version_id: {version_id}")
+            print(f"allowed_versions: {allowed_versions}")
+            print(f"max_time: {max_time}")
             
             count = 1
             
-            # print(f"{'-' * 12} COUNT {count} {'-' * 12}")
-            # print("filter: {}".format(allowed_versions.filter(pk=version_id).exists()))
+            print(f"{'-' * 12} COUNT {count} {'-' * 12}")
+            print("filter: {}".format(allowed_versions.filter(pk=version_id).exists()))
             
             while (not allowed_versions.filter(pk=version_id).exists() and count < max_time):
                 version = policy_function(variables,context)
@@ -232,12 +237,14 @@ class Policy(models.Model):
                     version_id = version.id
                 count += 1
                 
-                # print(f"version_id: {version_id}")
+                print(f"version_id: {version_id}")
                 
-                # print(f"{'-' * 12} COUNT {count} {'-' * 12}")
+                print(f"{'-' * 12} COUNT {count} {'-' * 12}")
             
             if count == max_time:
-                version = choice(list(allowed_versions))
+                all_allowed_pks = allowed_versions.values_list('pk', flat=True)
+                version_pk = choice(all_allowed_pks)
+                version = allowed_versions.get(pk=version_pk)
                 
                 print(f"tried {max_time} times")
                 print(f"randomly select an arm: {version}")

--- a/mooclet_engine/engine/views.py
+++ b/mooclet_engine/engine/views.py
@@ -67,17 +67,27 @@ class MoocletViewSet(viewsets.ModelViewSet):
         if "mooclet" in serialized_version:
             version_shown.mooclet = Mooclet.objects.get(pk=serialized_version["mooclet"])
         version_shown.save()
+        
+        if "policy" not in serialized_version:
+            serialized_version["policy"] = self.get_object().policy.name
+        if "policy_id" not in serialized_version:
+            serialized_version["policy_id"] = self.get_object().policy.id
+        
         return Response(serialized_version)
     
     @action(detail=True, methods=["post"])
     def run_with_arms(self, request, pk=None):
-        req = json.loads(request.body)
-        policy = request.POST.get('policy',None)
+        req = dict(request.data)
+        print("method: {}".format(request.method))
+        print("req: {}".format(request.data))
+        print("get: {}".format(request.GET))
+        policy = request.GET.get('policy',None)
+        
         context = {}
         learner = None
-        if request.POST.get('user_id', None):
+        if request.GET.get('user_id', None):
             learner, created = Learner.objects.get_or_create(name=request.GET.get('user_id', None))
-        elif request.POST.get('learner', None):
+        elif request.GET.get('learner', None):
             learner, created = Learner.objects.get_or_create(name=request.GET.get('learner', None))
         context['learner'] = learner
         
@@ -122,6 +132,12 @@ class MoocletViewSet(viewsets.ModelViewSet):
         if "mooclet" in serialized_version:
             version_shown.mooclet = Mooclet.objects.get(pk=serialized_version["mooclet"])
         version_shown.save()
+        
+        if "policy" not in serialized_version:
+            serialized_version["policy"] = self.get_object().policy.name
+        if "policy_id" not in serialized_version:
+            serialized_version["policy_id"] = self.get_object().policy.id
+        
         return Response(serialized_version)
 
 class VersionViewSet(viewsets.ModelViewSet):

--- a/mooclet_engine/engine/views.py
+++ b/mooclet_engine/engine/views.py
@@ -81,14 +81,14 @@ class MoocletViewSet(viewsets.ModelViewSet):
         print("method: {}".format(request.method))
         print("req: {}".format(request.data))
         print("get: {}".format(request.GET))
-        policy = request.GET.get('policy',None)
+        policy = req.get('policy',None)
         
         context = {}
         learner = None
-        if request.GET.get('user_id', None):
-            learner, created = Learner.objects.get_or_create(name=request.GET.get('user_id', None))
-        elif request.GET.get('learner', None):
-            learner, created = Learner.objects.get_or_create(name=request.GET.get('learner', None))
+        if req.get('user_id', None):
+            learner, created = Learner.objects.get_or_create(name=req.get('user_id', None))
+        elif req.get('learner', None):
+            learner, created = Learner.objects.get_or_create(name=req.get('learner', None))
         context['learner'] = learner
         
         # print(f"req: {req}")


### PR DESCRIPTION
Some Major Updates
---
1. Add POST request `run_with_arms` for running the mooclet given allowed arm names and maximum times for sampling.
2. Add "policy" and "policy_id" to the Response body in both `run` and `run_with_arms` requests when the mooclet is not using "choose_policy_group" or "choose_mooclet_group".