### PR TITLE
fix random pick from given arms if timeout issue

### DIFF
--- a/mooclet_engine/engine/policies.py
+++ b/mooclet_engine/engine/policies.py
@@ -106,7 +106,7 @@ def choose_policy_group(variables, context):
 
 		if not allowed_versions.filter(pk=version_id).exists() and count == context.get("maximum_allowed", 20):
 			print("RANDOM CHOOSE")
-			version = choice(context['mooclet'].version_set.all())
+			version = choice(allowed_versions)
 
 	if type(version) != dict:
 		version_dict = model_to_dict(version)


### PR DESCRIPTION
Now the policy `choose_policy_group` will only pick a random arm from the given arm list when running the policy with API `run_with_arm`.

Note: 
1. this change won't affect API `run`;
2. if the user uses the API `run_with_arm` but does not provide a corresponding arm list, the policy will be down-graded to `run` API.